### PR TITLE
Add AppServiceChan

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -44,6 +44,7 @@ func main() {
 			"auto.offset.reset": "latest",
 		},
 	}
-
-	run.Run(*applicationProperties)
+	
+        appServicesChan := make(chan internal.ApplicationServices)
+	run.Run(*applicationProperties, appServicesChan)
 }


### PR DESCRIPTION
Figured the app wouldn't compile as the `Run` signature changed. With this it the app boots at least:

```sh
./microcks.sh &
go run cmd/main.go
```